### PR TITLE
Update covers.js

### DIFF
--- a/src/js/covers.js
+++ b/src/js/covers.js
@@ -1,4 +1,4 @@
-const coversList = document.querySelectorAll('li');
+const coversList = document.querySelectorAll('.covers-list-item');
 const observer = new IntersectionObserver(handleIntersection, {
   root: null,
   rootMargin: '-25% 0px -25% 0px',


### PR DESCRIPTION
Проблема була в тому, що querySelectorAll('li') вибирає всі li на сторінці, а не лише в covers-section (щоб не було з іншими секціями конфліктів).

оновив на: 
const coversList = document.querySelectorAll('.covers-list-item');